### PR TITLE
fix macro WIN32_LEAN_AND_MEAN redefined

### DIFF
--- a/json_util.c
+++ b/json_util.c
@@ -38,7 +38,9 @@
 #endif /* HAVE_UNISTD_H */
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <io.h>
 #include <windows.h>
 #endif /* defined(_WIN32) */

--- a/linkhash.c
+++ b/linkhash.c
@@ -25,7 +25,9 @@
 #endif
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h> /* Get InterlockedCompareExchange */
 #endif
 


### PR DESCRIPTION
json-c as add_subdirectory and project cmakelists.txt has add_definitions(-DWIN32_LEAN_AND_MEAN)